### PR TITLE
Update student total correct after each response and fix youtube urls with special characters

### DIFF
--- a/actions/marktotalcorrect.php
+++ b/actions/marktotalcorrect.php
@@ -1,0 +1,49 @@
+<?php
+require_once "../../config.php";
+require_once('../dao/IV_DAO.php');
+
+use \Tsugi\Core\LTIX;
+use \IV\DAO\IV_DAO;
+
+$LAUNCH = LTIX::requireData();
+
+$p = $CFG->dbprefix;
+
+$IV_DAO = new IV_DAO($PDOX, $p);
+
+if (isset($_SESSION["videoId"])) {
+
+    $userId = $USER->id;
+    $videoId = $_SESSION["videoId"];
+
+    $IV_DAO->createFinishRecordIfNotExist($videoId, $userId);
+
+    $questions = $IV_DAO->getSortedQuestionsForVideo($videoId);
+
+    $questionNumber = 0;
+    $totalCorrect = 0;
+    foreach ($questions as $question) {
+        $questionNumber++;
+
+        // Get answers for question
+        $answers = $IV_DAO->getSortedAnswersForQuestion($question["question_id"]);
+        $correct = true;
+        foreach ($answers as $answer) {
+            $response = $IV_DAO->getResponse($userId, $question["question_id"], $answer["answer_id"]);
+            if ($answer["is_correct"] == 0 && $response) {
+                // Incorrect answer was chosen.
+                $correct = false;
+            } else if ($answer["is_correct"] == 1 && !$response) {
+                // Correct answer wasn't chosen.
+                $correct = false;
+            }
+        }
+
+        if ($correct) {
+            $totalCorrect++;
+        }
+    }
+
+    $IV_DAO->markStudentNumberCorrect($videoId, $userId, $totalCorrect);
+}
+return;

--- a/actions/recordresponses.php
+++ b/actions/recordresponses.php
@@ -12,6 +12,8 @@ $p = $CFG->dbprefix;
 
 $IV_DAO = new IV_DAO($PDOX, $p);
 
+header('Content-type: application/json');
+
 if (isset($_POST["questionId"])) {
 
     $userId = $USER->id;
@@ -25,4 +27,8 @@ if (isset($_POST["questionId"])) {
     foreach ($answerIds as $answerId) {
         $IV_DAO->recordResponse($userId, $questionId, $answerId);
     }
+    $response_arr["status"] = 'success';
+} else {
+    $response_arr["status"] = 'error';
 }
+echo (json_encode($response_arr));

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -875,17 +875,21 @@ var IntVideo = (function () {
         $.ajax({
             type: "POST",
             url: "actions/recordresponses.php?PHPSESSID="+sess,
+            dataType: "json",
             data: {
                 "questionId": questionId,
                 "answers": answerIds
+            },
+            success: function(data) {
+                if (data.status === 'success') {
+                    // Update student's score
+                    $.ajax({
+                        type: "POST",
+                        url: "actions/marktotalcorrect.php?PHPSESSID="+sess,
+                        data: {}
+                    });
+                }
             }
-        });
-
-        // Update student's score
-        $.ajax({
-            type: "POST",
-            url: "actions/marktotalcorrect.php?PHPSESSID="+sess,
-            data: {}
         });
 
         var questionTime, correct = true;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -549,7 +549,7 @@ var IntVideo = (function () {
         } else if (_videoType === typeEnum.YouTube) {
             let youtubeID = _videoUrl.split('v=')[1];
             let ampersandPosition = youtubeID.indexOf('&');
-            if(ampersandPosition != -1) {
+            if(ampersandPosition !== -1) {
                 youtubeID = youtubeID.substring(0, ampersandPosition);
             }
             $("#buildVideo").html(
@@ -568,7 +568,11 @@ var IntVideo = (function () {
                 + '?share=0&title=0&controls=0" frameborder="0" scrolling="0" allowfullscreen></iframe>'
             );
         } else if (_videoType === typeEnum.YouTube) {
-            var youtubeID = _videoUrl.match(/youtube\.com.*?v[\/=](\w+)/)[1];
+            let youtubeID = _videoUrl.split('v=')[1];
+            let ampersandPosition = youtubeID.indexOf('&');
+            if(ampersandPosition !== -1) {
+                youtubeID = youtubeID.substring(0, ampersandPosition);
+            }
             $("#playVideo").html(
                 '<iframe id="ytvideo" src="https://www.youtube.com/embed/'
                 + youtubeID
@@ -875,6 +879,13 @@ var IntVideo = (function () {
                 "questionId": questionId,
                 "answers": answerIds
             }
+        });
+
+        // Update student's score
+        $.ajax({
+            type: "POST",
+            url: "actions/marktotalcorrect.php?PHPSESSID="+sess,
+            data: {}
         });
 
         var questionTime, correct = true;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -547,7 +547,11 @@ var IntVideo = (function () {
                 + '" frameborder="0" scrolling="0" allowfullscreen></iframe>'
             );
         } else if (_videoType === typeEnum.YouTube) {
-            var youtubeID = _videoUrl.match(/youtube\.com.*?v[\/=](\w+)/)[1];
+            let youtubeID = window.location.search.split('v=')[1];
+            let ampersandPosition = youtubeID.indexOf('&');
+            if(ampersandPosition != -1) {
+                youtubeID = youtubeID.substring(0, ampersandPosition);
+            }
             $("#buildVideo").html(
                 '<iframe id="ytvideo" src="https://www.youtube.com/embed/'
                 + youtubeID

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -547,7 +547,7 @@ var IntVideo = (function () {
                 + '" frameborder="0" scrolling="0" allowfullscreen></iframe>'
             );
         } else if (_videoType === typeEnum.YouTube) {
-            let youtubeID = window.location.search.split('v=')[1];
+            let youtubeID = _videoUrl.split('v=')[1];
             let ampersandPosition = youtubeID.indexOf('&');
             if(ampersandPosition != -1) {
                 youtubeID = youtubeID.substring(0, ampersandPosition);


### PR DESCRIPTION
A student only had a score if they got all the way to the end of the video and waited for the scores page to load OR if an instructor clicked on their name on the results page. This change makes it so a student's total correct gets updated after each response.
Additionally, there was an issue pulling the youtube video id if it had special characters that is now fixed.